### PR TITLE
problem: docker builds upload the large vendor tree, slowing down con…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+vendor
+pkg


### PR DESCRIPTION
…tainer builds

solution: Add the pkg and vendor dirs to a (new) `.dockerignore` file
to avoid uploading those unneeded directories to docker during the
build process